### PR TITLE
Adds a few Swashbuckle annotations when built with optional target

### DIFF
--- a/ASCOM.Alpaca.Device/ASCOM.Alpaca.Device.csproj
+++ b/ASCOM.Alpaca.Device/ASCOM.Alpaca.Device.csproj
@@ -18,6 +18,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\ASCOM.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
+    <Configurations>Debug;Release;Swashbuckle_Documentation</Configurations>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/ASCOM.Alpaca/ASCOM.Alpaca.csproj
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.csproj
@@ -18,6 +18,7 @@
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>..\ASCOM.snk</AssemblyOriginatorKeyFile>
 		<DelaySign>false</DelaySign>
+		<Configurations>Debug;Release;Swashbuckle_Documentation</Configurations>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/ASCOM.Com/ASCOM.Com.csproj
+++ b/ASCOM.Com/ASCOM.Com.csproj
@@ -13,6 +13,7 @@
 		<PackageIcon>ASCOMBoarderless.png</PackageIcon>
 		<PackageTags>ascom;alpaca;com;driveraccess</PackageTags>
 		<Product>ASCOM COM Components</Product>
+		<Configurations>Debug;Release;Swashbuckle_Documentation</Configurations>
 		</PropertyGroup>
 
 	<ItemGroup>

--- a/ASCOM.Common/ASCOM.Common.Alpaca/AlpacaResponses/Response.cs
+++ b/ASCOM.Common/ASCOM.Common.Alpaca/AlpacaResponses/Response.cs
@@ -1,6 +1,11 @@
 ﻿using ASCOM.Common.Com;
 using System;
 
+#if Swashbuckle_Documentation
+using Swashbuckle.AspNetCore.Annotations;
+using System.ComponentModel.DataAnnotations;
+#endif
+
 namespace ASCOM.Common.Alpaca
 {
     /// <summary>
@@ -16,11 +21,19 @@ namespace ASCOM.Common.Alpaca
         /// <summary>
         /// Client's transaction ID (0 to 4294967295), as supplied by the client in the command request.
         /// </summary>
+#if Swashbuckle_Documentation
+        [SwaggerSchema(Format = "uint32")]
+        [Range(0, 4294967295)]
+#endif
         public uint ClientTransactionID { get; set; }
 
         /// <summary>
         /// Server's transaction ID (0 to 4294967295), should be unique for each client transaction so that log messages on the client can be associated with logs on the device.
         /// </summary>
+#if Swashbuckle_Documentation
+        [SwaggerSchema(Format = "uint32")]
+        [Range(0, 4294967295)]
+#endif
         public uint ServerTransactionID { get; set; }
 
         /// <summary>
@@ -28,6 +41,9 @@ namespace ASCOM.Common.Alpaca
         /// numbers whenever appropriate so that clients can take informed actions. E.g.returning 0x401 (1025) to indicate that an invalid value was received.
         /// </summary>
         /// <seealso cref="AlpacaErrors"/>
+#if Swashbuckle_Documentation
+        [Range(-2147483648, 2147483647)]
+#endif
         public AlpacaErrors ErrorNumber { get; set; }
 
         /// <summary>
@@ -36,10 +52,15 @@ namespace ASCOM.Common.Alpaca
         /// </summary>
         public string ErrorMessage { get; set; } = "";
 
+        //Do not include DriverException in the Swashbuckle documentation, it is not part of the standard returns
+
         /// <summary>
         /// Optional field for Windows drivers to return an exception to the client application.
         /// </summary>
         /// <remarks>Populating this automatically sets the ErrorMessage and ErrorNumber fields; COM errors in the range 0x80040400 to 0x8040FFF are translated to equivalent Alpaca error numbers in the range 0x400 to 0xFFF.</remarks>
+#if Swashbuckle_Documentation
+        [System.Text.Json.Serialization.JsonIgnore]
+#endif
         public Exception DriverException
         {
             get

--- a/ASCOM.Common/ASCOM.Common.csproj
+++ b/ASCOM.Common/ASCOM.Common.csproj
@@ -43,7 +43,7 @@
 	</ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' == 'Swashbuckle_Documentation' ">
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/ASCOM.Common/ASCOM.Common.csproj
+++ b/ASCOM.Common/ASCOM.Common.csproj
@@ -14,12 +14,22 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageId>ASCOM.Common.Components</PackageId>
 		<PackageIcon>ASCOMBoarderless.png</PackageIcon>
+		<Configurations>Debug;Release;Swashbuckle_Documentation</Configurations>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<DebugType>embedded</DebugType>
 		<Optimize>False</Optimize>
 	</PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Swashbuckle_Documentation|AnyCPU'">
+    <DefineConstants>TRACE;Swashbuckle_Documentation</DefineConstants>
+  </PropertyGroup>
 
 	<ItemGroup>
 	  <None Include="..\ASCOMBoarderless.png">
@@ -31,6 +41,10 @@
 	<ItemGroup>
 	  <PackageReference Include="ASCOM.Exceptions" Version="6.5.1" />
 	</ItemGroup>
+
+  <ItemGroup Condition=" '$(Configuration)' == 'Swashbuckle_Documentation' ">
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.4" />
+  </ItemGroup>
 
 	<ItemGroup>
 	  <None Update="README.md">

--- a/ASCOM.Tools/ASCOM.Tools.csproj
+++ b/ASCOM.Tools/ASCOM.Tools.csproj
@@ -10,6 +10,7 @@
 		<Authors>Daniel Van Noord, Peter Simpson</Authors>
 		<Description>A set of components to support development of ASCOM clients, drivers and Alapca devices.</Description>
 		<PackageIcon>ASCOMBoarderless.png</PackageIcon>
+		<Configurations>Debug;Release;Swashbuckle_Documentation</Configurations>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/ASCOMStandard.sln
+++ b/ASCOMStandard.sln
@@ -26,6 +26,8 @@ Global
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
 		Release|x86 = Release|x86
+		Swashbuckle_Documentation|Any CPU = Swashbuckle_Documentation|Any CPU
+		Swashbuckle_Documentation|x86 = Swashbuckle_Documentation|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EC97A23E-7CB2-43A8-A351-CC4FDDA9CE2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -36,6 +38,10 @@ Global
 		{EC97A23E-7CB2-43A8-A351-CC4FDDA9CE2C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{EC97A23E-7CB2-43A8-A351-CC4FDDA9CE2C}.Release|x86.ActiveCfg = Release|Any CPU
 		{EC97A23E-7CB2-43A8-A351-CC4FDDA9CE2C}.Release|x86.Build.0 = Release|Any CPU
+		{EC97A23E-7CB2-43A8-A351-CC4FDDA9CE2C}.Swashbuckle_Documentation|Any CPU.ActiveCfg = Swashbuckle_Documentation|Any CPU
+		{EC97A23E-7CB2-43A8-A351-CC4FDDA9CE2C}.Swashbuckle_Documentation|Any CPU.Build.0 = Swashbuckle_Documentation|Any CPU
+		{EC97A23E-7CB2-43A8-A351-CC4FDDA9CE2C}.Swashbuckle_Documentation|x86.ActiveCfg = Swashbuckle_Documentation|Any CPU
+		{EC97A23E-7CB2-43A8-A351-CC4FDDA9CE2C}.Swashbuckle_Documentation|x86.Build.0 = Swashbuckle_Documentation|Any CPU
 		{F0C9BFFD-C144-44AF-9318-847B19DF5C5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F0C9BFFD-C144-44AF-9318-847B19DF5C5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F0C9BFFD-C144-44AF-9318-847B19DF5C5B}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -44,6 +50,10 @@ Global
 		{F0C9BFFD-C144-44AF-9318-847B19DF5C5B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F0C9BFFD-C144-44AF-9318-847B19DF5C5B}.Release|x86.ActiveCfg = Release|Any CPU
 		{F0C9BFFD-C144-44AF-9318-847B19DF5C5B}.Release|x86.Build.0 = Release|Any CPU
+		{F0C9BFFD-C144-44AF-9318-847B19DF5C5B}.Swashbuckle_Documentation|Any CPU.ActiveCfg = Swashbuckle_Documentation|Any CPU
+		{F0C9BFFD-C144-44AF-9318-847B19DF5C5B}.Swashbuckle_Documentation|Any CPU.Build.0 = Swashbuckle_Documentation|Any CPU
+		{F0C9BFFD-C144-44AF-9318-847B19DF5C5B}.Swashbuckle_Documentation|x86.ActiveCfg = Swashbuckle_Documentation|Any CPU
+		{F0C9BFFD-C144-44AF-9318-847B19DF5C5B}.Swashbuckle_Documentation|x86.Build.0 = Swashbuckle_Documentation|Any CPU
 		{E0DA83D6-2F10-4A2E-B34A-1113335E2375}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E0DA83D6-2F10-4A2E-B34A-1113335E2375}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E0DA83D6-2F10-4A2E-B34A-1113335E2375}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -52,6 +62,10 @@ Global
 		{E0DA83D6-2F10-4A2E-B34A-1113335E2375}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E0DA83D6-2F10-4A2E-B34A-1113335E2375}.Release|x86.ActiveCfg = Release|Any CPU
 		{E0DA83D6-2F10-4A2E-B34A-1113335E2375}.Release|x86.Build.0 = Release|Any CPU
+		{E0DA83D6-2F10-4A2E-B34A-1113335E2375}.Swashbuckle_Documentation|Any CPU.ActiveCfg = Swashbuckle_Documentation|Any CPU
+		{E0DA83D6-2F10-4A2E-B34A-1113335E2375}.Swashbuckle_Documentation|Any CPU.Build.0 = Swashbuckle_Documentation|Any CPU
+		{E0DA83D6-2F10-4A2E-B34A-1113335E2375}.Swashbuckle_Documentation|x86.ActiveCfg = Swashbuckle_Documentation|Any CPU
+		{E0DA83D6-2F10-4A2E-B34A-1113335E2375}.Swashbuckle_Documentation|x86.Build.0 = Swashbuckle_Documentation|Any CPU
 		{15505B99-58E8-4CA7-87B0-BEDF9F2FF990}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{15505B99-58E8-4CA7-87B0-BEDF9F2FF990}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{15505B99-58E8-4CA7-87B0-BEDF9F2FF990}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -60,6 +74,10 @@ Global
 		{15505B99-58E8-4CA7-87B0-BEDF9F2FF990}.Release|Any CPU.Build.0 = Release|Any CPU
 		{15505B99-58E8-4CA7-87B0-BEDF9F2FF990}.Release|x86.ActiveCfg = Release|Any CPU
 		{15505B99-58E8-4CA7-87B0-BEDF9F2FF990}.Release|x86.Build.0 = Release|Any CPU
+		{15505B99-58E8-4CA7-87B0-BEDF9F2FF990}.Swashbuckle_Documentation|Any CPU.ActiveCfg = Swashbuckle_Documentation|Any CPU
+		{15505B99-58E8-4CA7-87B0-BEDF9F2FF990}.Swashbuckle_Documentation|Any CPU.Build.0 = Swashbuckle_Documentation|Any CPU
+		{15505B99-58E8-4CA7-87B0-BEDF9F2FF990}.Swashbuckle_Documentation|x86.ActiveCfg = Swashbuckle_Documentation|Any CPU
+		{15505B99-58E8-4CA7-87B0-BEDF9F2FF990}.Swashbuckle_Documentation|x86.Build.0 = Swashbuckle_Documentation|Any CPU
 		{777AE5B4-4DF7-4382-9461-7A1A0D8C49D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{777AE5B4-4DF7-4382-9461-7A1A0D8C49D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{777AE5B4-4DF7-4382-9461-7A1A0D8C49D4}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -68,6 +86,10 @@ Global
 		{777AE5B4-4DF7-4382-9461-7A1A0D8C49D4}.Release|Any CPU.Build.0 = Release|Any CPU
 		{777AE5B4-4DF7-4382-9461-7A1A0D8C49D4}.Release|x86.ActiveCfg = Release|Any CPU
 		{777AE5B4-4DF7-4382-9461-7A1A0D8C49D4}.Release|x86.Build.0 = Release|Any CPU
+		{777AE5B4-4DF7-4382-9461-7A1A0D8C49D4}.Swashbuckle_Documentation|Any CPU.ActiveCfg = Swashbuckle_Documentation|Any CPU
+		{777AE5B4-4DF7-4382-9461-7A1A0D8C49D4}.Swashbuckle_Documentation|Any CPU.Build.0 = Swashbuckle_Documentation|Any CPU
+		{777AE5B4-4DF7-4382-9461-7A1A0D8C49D4}.Swashbuckle_Documentation|x86.ActiveCfg = Swashbuckle_Documentation|Any CPU
+		{777AE5B4-4DF7-4382-9461-7A1A0D8C49D4}.Swashbuckle_Documentation|x86.Build.0 = Swashbuckle_Documentation|Any CPU
 		{95BB0001-3F6C-405A-A343-D63F96D7975C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{95BB0001-3F6C-405A-A343-D63F96D7975C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{95BB0001-3F6C-405A-A343-D63F96D7975C}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -76,6 +98,10 @@ Global
 		{95BB0001-3F6C-405A-A343-D63F96D7975C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{95BB0001-3F6C-405A-A343-D63F96D7975C}.Release|x86.ActiveCfg = Release|Any CPU
 		{95BB0001-3F6C-405A-A343-D63F96D7975C}.Release|x86.Build.0 = Release|Any CPU
+		{95BB0001-3F6C-405A-A343-D63F96D7975C}.Swashbuckle_Documentation|Any CPU.ActiveCfg = Swashbuckle_Documentation|Any CPU
+		{95BB0001-3F6C-405A-A343-D63F96D7975C}.Swashbuckle_Documentation|Any CPU.Build.0 = Swashbuckle_Documentation|Any CPU
+		{95BB0001-3F6C-405A-A343-D63F96D7975C}.Swashbuckle_Documentation|x86.ActiveCfg = Swashbuckle_Documentation|Any CPU
+		{95BB0001-3F6C-405A-A343-D63F96D7975C}.Swashbuckle_Documentation|x86.Build.0 = Swashbuckle_Documentation|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/ASCOMStandard.Tests/UnitTests.csproj
+++ b/test/ASCOMStandard.Tests/UnitTests.csproj
@@ -6,6 +6,8 @@
         <IsPackable>false</IsPackable>
 
         <RootNamespace>ASCOM.Alpaca.Tests</RootNamespace>
+
+        <Configurations>Debug;Release;Swashbuckle_Documentation</Configurations>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
This should only pull the Swashbuckle package when built with Swashbuckle_Documentation.